### PR TITLE
Add test for when the a row has only zeros and l2 norm is zero

### DIFF
--- a/chunkdot/cosine_similarity_top_k.py
+++ b/chunkdot/cosine_similarity_top_k.py
@@ -52,11 +52,11 @@ def cosine_similarity_top_k(
     # return type consistent with sklearn.pairwise.cosine_similarity function
     return_type = "float32" if embeddings.dtype == np.float32 else "float64"
     if normalize:
-        embeddings = (
-            embeddings
-            / np.sqrt(np.einsum("ij,ij->i", embeddings, embeddings, dtype=return_type))[
-                :, np.newaxis
-            ]
+        norms = np.sqrt(np.einsum("ij,ij->i", embeddings, embeddings, dtype=return_type))[
+            :, np.newaxis
+        ]
+        embeddings = np.divide(
+            embeddings, norms, out=np.zeros_like(embeddings, dtype=return_type), where=norms != 0
         )
 
     n_rows = len(embeddings)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,12 @@ build-backend = "poetry.core.masonry.api"
 [tool.black]
 line-length = 100
 
+[tool.pytest.ini_options]
+addopts = "-x --log-cli-level=INFO"
+testpaths = [
+    "tests",
+]
+
 [tool.pylint.messages_control]
 max-line-length = 100
 max-args = 10

--- a/tests/cosine_similarity_top_k_test.py
+++ b/tests/cosine_similarity_top_k_test.py
@@ -137,3 +137,12 @@ def test_cosine_similarity_negative_top_k_manual(input_type):
     calculated = cosine_similarity_top_k(embeddings, top_k)
     assert calculated.dtype == expected.dtype
     np.testing.assert_array_almost_equal(calculated.toarray(), expected)
+
+
+@pytest.mark.parametrize("top_k", [1, 2, 3])
+def test_cosine_similarity_negative_top_k_zero_rows(top_k):
+    embeddings = np.array([[0, 0, 0], [34, 22, 11], [0, 0, 0], [11, 21, 34]])
+    expected = cosine_similarity(embeddings)
+    expected = get_top_k(expected, top_k)
+    calculated = cosine_similarity_top_k(embeddings, top_k)
+    np.testing.assert_array_almost_equal(calculated.toarray(), expected.toarray())


### PR DESCRIPTION
At the moment the behaviour is different than in the SKLean cosine similarity function if there are rows with only zeros. This PR fixes that bug and aligns the result with that of SKLearn. If the norm of a row is zero it leaves the row with all zeros as is.