### PR TITLE
Support sparse matrices

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Multi-threaded matrix multiplication and cosine similarity calculations. Appropr
 pip install -U chunkdot
 ```
 
+### Dense embeddings
+
 Calculate the 50 most similar and dissimilar items for 100K items.
 
 ```python
@@ -25,8 +27,7 @@ cosine_similarity_top_k(embeddings, top_k=-50, max_memory=20E9)
  with 5000000 stored elements in Compressed Sparse Row format>
 ```
 
-## The execution time
-
+Execution time
 ```python
 from timeit import timeit
 import numpy as np
@@ -37,4 +38,37 @@ timeit(lambda: cosine_similarity_top_k(embeddings, top_k=50, max_memory=20E9), n
 ```
 ```
 58.611996899999994
+```
+
+### Sparse embeddings
+
+Calculate the 50 most similar and dissimilar items for 100K items. Items represented by 10K dimensional vectors and an embeddings matrix of 0.005 density.
+
+```python
+from scipy import sparse
+from chunkdot import cosine_similarity_top_k
+
+embeddings = sparse.rand(100000, 10000, density=0.005)
+# using all you system's memory
+cosine_similarity_top_k(embeddings, top_k=50)
+# most dissimilar items using 20GB
+cosine_similarity_top_k(embeddings, top_k=-50, max_memory=20E9)
+```
+```
+<100000x100000 sparse matrix of type '<class 'numpy.float64'>'
+ with 5000000 stored elements in Compressed Sparse Row format>
+```
+
+Execution time
+
+```python
+from timeit import timeit
+from scipy import sparse
+from chunkdot import cosine_similarity_top_k
+
+embeddings = sparse.rand(100000, 10000, density=0.005)
+timeit(lambda: cosine_similarity_top_k(embeddings, top_k=50, max_memory=20E9), number=1)
+```
+```
+51.87472256699999
 ```

--- a/chunkdot/chunkdot.py
+++ b/chunkdot/chunkdot.py
@@ -5,6 +5,12 @@ from scipy.sparse import csr_matrix
 from chunkdot.utils import to_sparse
 
 
+def warm_up_chunkdot():
+    """Make a dummy run of the "chunkdot" function to compile it."""
+    matrix = np.random.randn(10000, 100)
+    chunkdot(matrix, matrix.T, 10, 5000)
+
+
 @njit(parallel=True)
 def _chunkdot(matrix_left, matrix_right, top_k, chunk_size):
     """Parallelize matrix multiplication by converting the left matrix into chunks."""

--- a/chunkdot/chunkdot_sparse.py
+++ b/chunkdot/chunkdot_sparse.py
@@ -1,8 +1,18 @@
+import logging
 import math
 import numpy as np
 from numba import njit, prange
-from scipy.sparse import csr_matrix
+from scipy.sparse import csr_matrix, rand as srand
 from chunkdot.utils import to_sparse
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+def warm_up_chunkdot_sparse():
+    """Make a dummy run of the "chunkdot" function to compile it."""
+    matrix = srand(10000, 100, density=0.01, format="csr")
+    chunkdot_sparse(matrix, matrix.T, 10, 5000)
 
 
 # Noting to parallelize in this function. It will raise an error if setting parallel to True since
@@ -16,9 +26,30 @@ def sparse_dot_rowwise(
     matrix_right_indices,
     matrix_right_indptr,
 ):
+    """Sparse matrix multiplication matrix_left x matrix_right.T
+
+    Data, indices and indptr are the standard CSR representation where the column indices for row i
+    are stored in indices[indptr[i]:indptr[i+1]] and their corresponding values are stored in
+    data[indptr[i]:indptr[i+1]].
+
+    Note that the matrix_right would need still to be transposed according to the mathematical
+    expression of matrix multiplication. In this algorithm we do not transpose it as the iteration
+    is over the rows of each matrix.
+
+    Args:
+        matrix_left_data (numpy.array): Non-zero value of the sparse matrix.
+        matrix_left_indices (numpy.array): Column positions of non-zero values.
+        matrix_left_indptr (numpy.array): Array with the count of non-zero values per row.
+        matrix_right_data (numpy.array): Non-zero value of the sparse matrix.
+        matrix_right_indices (numpy.array): Column positions of non-zero values.
+        matrix_right_indptr (numpy.array): Array with the count of non-zero values per row.
+
+    Returns:
+        numpy.array: 2D array with the result of the matrix multiplication.
+    """
     left_n_rows = len(matrix_left_indptr) - 1
     right_n_rows = len(matrix_right_indptr) - 1
-    similarities = np.empty((left_n_rows, right_n_rows))
+    values = np.empty((left_n_rows, right_n_rows))
     for row_left in range(left_n_rows):  # loop over rows of left matrix
         for row_right in range(right_n_rows):  # loop over rows of right matrix
             value = 0
@@ -31,14 +62,28 @@ def sparse_dot_rowwise(
                     if matrix_left_indices[left_i] == matrix_right_indices[right_i]:
                         # both rows have a non-zero value at this column index
                         value += matrix_left_data[left_i] * matrix_right_data[right_i]
-            similarities[row_left, row_right] = value
-    return similarities
+            values[row_left, row_right] = value
+    return values
 
 
 # Noting to parallelize in this function. It will raise an error if setting parallel to True since
 # the calling functions are already being parallelized.
 @njit(parallel=False)
 def slice_csr_sparse(data, indices, indptr, start_row, end_row):
+    """Get row-wise slice of sparse matrix.
+
+    Data, indices and indptr are the standard CSR representation where the column indices for row i
+    are stored in indices[indptr[i]:indptr[i+1]] and their corresponding values are stored in
+    data[indptr[i]:indptr[i+1]].
+
+    Args:
+        data (numpy.array): Non-zero value of the sparse matrix.
+        indices (numpy.array): Column positions of non-zero values.
+        indptr (numpy.array): Array with the count of non-zero values per row.
+
+    Returns:
+        3 arrays containing the sparse CSR matrix information of the slice.
+    """
     left_i = indptr[start_row]
     end_row = min(end_row, len(indptr) - 1)
     right_i = indptr[end_row]
@@ -60,7 +105,13 @@ def _chunkdot_sparse_rowwise(
     top_k,
     chunk_size,
 ):
-    """Parallelize matrix multiplication by converting the left matrix into chunks."""
+    """Parallelize the sparse matrix multiplication by converting the left matrix into chunks.
+
+    Note that the matrix_right would still need to be transposed according to the mathematical
+    expression of matrix multiplication. In this algorithm we do not transpose it as the iteration
+    is over the rows of each matrix.
+    """
+    # pylint: disable=too-many-locals, duplicate-code
     n_rows = len(matrix_left_indptr) - 1
     abs_top_k = abs(top_k)
     n_non_zero = n_rows * abs_top_k
@@ -94,11 +145,13 @@ def _chunkdot_sparse_rowwise(
 
 
 def chunkdot_sparse(matrix_left, matrix_right, top_k, chunk_size, return_type="float64"):
-    """Parallelize matrix multiplication by converting the left matrix into chunks.
+    """Parallelize sparse matrix multiplication by converting the left matrix into chunks.
 
     Args:
-        matrix_left (np.array): The left matrix in the matrix multiplication operation.
-        matrix_right (np.array): The right matrix in the matrix multiplication operation.
+        matrix_left (scipy.sparse.csr_matrix): The left sparse matrix in the matrix multiplication
+            operation.
+        matrix_right (scipy.sparse.csr_matrix): The right sparse matrix in the matrix
+            multiplication operation.
         top_k (int): Keep only the biggest K values per row in the resulting matrix.
         chunk_size (int): The number of rows in the matrix_left to use per parallelized
             calculation.
@@ -107,10 +160,26 @@ def chunkdot_sparse(matrix_left, matrix_right, top_k, chunk_size, return_type="f
     Returns:
         scipy.sparse.csr_matrix: The result of the matrix multiplication as a CSR sparse matrix.
     """
+    if matrix_left.shape[1] != matrix_right.shape[0]:
+        raise ValueError(
+            "Incorrect matrix dimensions for matrix multiplication. Left matrix has shape="
+            f"({matrix_left.shape}) and right matrix has shape={matrix_right.shape}"
+        )
+
     n_rows = matrix_left.shape[0]
     matrix_right = matrix_right.T
-    if matrix_left.shape[1] != matrix_right.shape[1]:
-        raise ValueError("Incorrect matrix dimensions")
+
+    # Algorithm is made for CSR sparse matrices only
+    left_format = matrix_left.getformat()
+    if left_format != "csr":
+        LOGGER.debug(f"Converting left matrix format from {left_format.upper()} to CSR.")
+        matrix_left = matrix_left.tocsr()
+
+    right_format = matrix_left.getformat()
+    if right_format != "csr":
+        LOGGER.debug(f"Converting right matrix format from {right_format.upper()} to CSR.")
+        matrix_right = matrix_right.tocsr()
+
     n_cols = matrix_right.shape[0]
     values, indices, indptr = _chunkdot_sparse_rowwise(
         matrix_left.data,

--- a/chunkdot/chunkdot_sparse.py
+++ b/chunkdot/chunkdot_sparse.py
@@ -1,0 +1,121 @@
+import math
+import numpy as np
+from numba import njit, prange
+from scipy.sparse import csr_matrix
+from chunkdot.utils import to_sparse
+
+
+# Noting to parallelize in this function. It will raise an error if setting parallel to True since
+# the calling functions are already being parallelized.
+@njit(parallel=False)
+def sparse_dot_rowwise(
+    matrix_left_data,
+    matrix_left_indices,
+    matrix_left_indptr,
+    matrix_right_data,
+    matrix_right_indices,
+    matrix_right_indptr,
+):
+    left_n_rows = len(matrix_left_indptr) - 1
+    right_n_rows = len(matrix_right_indptr) - 1
+    similarities = np.zeros((left_n_rows, right_n_rows))
+    for row_left in range(len(matrix_left_indptr) - 1):
+        for row_right in range(len(matrix_right_indptr) - 1):
+            value = 0
+            for left_i in range(matrix_left_indptr[row_left], matrix_left_indptr[row_left + 1]):
+                column_left_i = matrix_left_indices[left_i]
+                for right_i in range(
+                    matrix_right_indptr[row_right], matrix_right_indptr[row_right + 1]
+                ):
+                    column_right_i = matrix_right_indices[right_i]
+                    if column_left_i == column_right_i:
+                        value += matrix_left_data[left_i] * matrix_left_data[right_i]
+            if value != 0:
+                similarities[row_left, row_right] = value
+    return similarities
+
+
+# Noting to parallelize in this function. It will raise an error if setting parallel to True since
+# the calling functions are already being parallelized.
+@njit(parallel=False)
+def slice_csr_sparse(data, indices, indptr, start_row, end_row):
+    left_i = indptr[start_row]
+    right_i = indptr[end_row]
+    return data[left_i:right_i], indices[left_i:right_i], indptr[start_row : end_row + 1]
+
+
+@njit(parallel=True)
+def _chunkdot_sparse_rowwise(
+    matrix_left_data,
+    matrix_left_indices,
+    matrix_left_indptr,
+    matrix_right_data,
+    matrix_right_indices,
+    matrix_right_indptr,
+    top_k,
+    chunk_size,
+):
+    """Parallelize matrix multiplication by converting the left matrix into chunks."""
+    n_rows = len(matrix_left_indptr) - 1
+    abs_top_k = abs(top_k)
+    n_non_zero = n_rows * abs_top_k
+    all_values, all_indices = (
+        np.zeros(n_non_zero, dtype="float64"),
+        np.empty(n_non_zero, dtype="int64"),
+    )
+    # Round up since the in the last iteration chunk <= chunk_size
+    for i in prange(0, math.ceil(n_rows / chunk_size)):  # pylint: disable=not-an-iterable
+        start_row_i, end_row_i = i * chunk_size, (i + 1) * chunk_size
+        data, indices, indptr = slice_csr_sparse(
+            matrix_left_data, matrix_left_indices, matrix_left_indptr, start_row_i, end_row_i
+        )
+        chunk_m = sparse_dot_rowwise(
+            data,
+            indices,
+            indptr,
+            matrix_right_data,
+            matrix_right_indices,
+            matrix_right_indptr,
+        )
+        to_sparse(
+            chunk_m,
+            top_k,
+            all_values[start_row_i * abs_top_k : end_row_i * abs_top_k],
+            all_indices[start_row_i * abs_top_k : end_row_i * abs_top_k],
+        )
+    # standard CSR form representation
+    all_indptr = np.arange(0, abs_top_k * (1 + n_rows), abs_top_k)
+    return all_values, all_indices, all_indptr
+
+
+def chunkdot_sparse(
+    matrix_left, matrix_right, top_k, chunk_size, return_type="float64", transpose_right=False
+):
+    """Parallelize matrix multiplication by converting the left matrix into chunks.
+
+    Args:
+        matrix_left (np.array): The left matrix in the matrix multiplication operation.
+        matrix_right (np.array): The right matrix in the matrix multiplication operation.
+        top_k (int): Keep only the biggest K values per row in the resulting matrix.
+        chunk_size (int): The number of rows in the matrix_left to use per parallelized
+            calculation.
+        return_type (str): The return type of the matrix elements.
+
+    Returns:
+        scipy.sparse.csr_matrix: The result of the matrix multiplication as a CSR sparse matrix.
+    """
+    n_rows = matrix_left.shape[0]
+    if not transpose_right:
+        matrix_right = matrix_right.T
+    n_cols = matrix_right.shape[0]
+    values, indices, indptr = _chunkdot_sparse_rowwise(
+        matrix_left.data,
+        matrix_left.indices,
+        matrix_left.indptr,
+        matrix_right.data,
+        matrix_right.indices,
+        matrix_right.indptr,
+        top_k,
+        chunk_size,
+    )
+    return csr_matrix((values.astype(return_type), indices, indptr), shape=(n_rows, n_cols))

--- a/chunkdot/chunkdot_sparse.py
+++ b/chunkdot/chunkdot_sparse.py
@@ -18,7 +18,7 @@ def warm_up_chunkdot_sparse():
 # Noting to parallelize in this function. It will raise an error if setting parallel to True since
 # the calling functions are already being parallelized.
 @njit(parallel=False)
-def sparse_dot_rowwise(
+def sparse_dot(
     matrix_left_data,
     matrix_left_indices,
     matrix_left_indptr,
@@ -113,7 +113,7 @@ def _chunkdot_sparse_rowwise(
         data, indices, indptr = slice_csr_sparse(
             matrix_left_data, matrix_left_indices, matrix_left_indptr, start_row_i, end_row_i
         )
-        chunk_m = sparse_dot_rowwise(
+        chunk_m = sparse_dot(
             data,
             indices,
             indptr,

--- a/chunkdot/cosine_similarity_top_k.py
+++ b/chunkdot/cosine_similarity_top_k.py
@@ -15,8 +15,8 @@ def cosine_similarity_top_k(
     """Calculate cosine similarity and only keep the K most similar items for each item.
 
     Args:
-        embeddings (np.array): 2D array containing the items embeddings. Array of size
-            number of items x embedding dimension.
+        embeddings (np.array or scipy.sparse matrix): 2D object containing the items embeddings,
+            of shape number of items x embedding dimension.
         top_k (int): The amount of similar items per item to return.
         normalize (bool): If to apply L2-norm to each row.
             Default True.

--- a/chunkdot/cosine_similarity_top_k.py
+++ b/chunkdot/cosine_similarity_top_k.py
@@ -1,6 +1,7 @@
 import numpy as np
-from scipy.sparse import issparse
+from scipy import sparse
 from chunkdot.chunkdot import chunkdot
+from chunkdot.chunkdot_sparse import chunkdot_sparse
 from chunkdot.utils import get_chunk_size_per_thread
 
 
@@ -46,28 +47,35 @@ def cosine_similarity_top_k(
             c. Collect such values and column indices into outer scope arrays.
         5. Create a CSR matrix from all values and indices and return it.
     """
-    if issparse(embeddings):
-        raise TypeError("ChunkDot does not yet support SciPy sparse matrices as input.")
-
     # return type consistent with sklearn.pairwise.cosine_similarity function
     return_type = "float32" if embeddings.dtype == np.float32 else "float64"
     if normalize:
-        norms = np.sqrt(np.einsum("ij,ij->i", embeddings, embeddings, dtype=return_type))[
-            :, np.newaxis
-        ]
-        embeddings = np.divide(
-            embeddings, norms, out=np.zeros_like(embeddings, dtype=return_type), where=norms != 0
-        )
+        if sparse.issparse(embeddings):
+            norm = sparse.linalg.norm(embeddings, ord=2, axis=1)
+            embeddings = sparse.diags(1 / norm) @ embeddings
+        else:
+            norms = np.linalg.norm(embeddings, ord=2, axis=1, keepdims=True)
+            embeddings = np.divide(
+                embeddings,
+                norms,
+                out=np.zeros_like(embeddings, dtype=return_type),
+                where=norms != 0,
+            )
 
-    n_rows = len(embeddings)
+    n_rows = embeddings.shape[0]
     abs_top_k = abs(top_k)
 
     if abs_top_k >= n_rows:
         raise ValueError(
             f"The number of requested similar items (top_k={abs_top_k}) must be less than the "
-            f"total number of items (len(embeddings)={len(embeddings)})"
+            f"total number of items (embeddings.shape[0]={n_rows})"
         )
 
     chunk_size_per_thread = get_chunk_size_per_thread(n_rows, abs_top_k, max_memory, force_memory)
-    similarities = chunkdot(embeddings, embeddings.T, top_k, chunk_size_per_thread, return_type)
+    if sparse.issparse(embeddings):
+        similarities = chunkdot_sparse(
+            embeddings, embeddings, top_k, chunk_size_per_thread, return_type, transpose_right=True
+        )
+    else:
+        similarities = chunkdot(embeddings, embeddings.T, top_k, chunk_size_per_thread, return_type)
     return similarities

--- a/chunkdot/utils.py
+++ b/chunkdot/utils.py
@@ -47,12 +47,6 @@ def get_memory_available():
     return psutil.virtual_memory().available
 
 
-def warm_up_chunked_dot():
-    """Make a dummy run of the "chunkdot" function to compile it."""
-    matrix = np.random.randn(10000, 100)
-    chunkdot(matrix, matrix.T, 10, 5000)
-
-
 def get_chunk_size_per_thread(n_items, top_k, max_memory=None, force_memory=False):
     """Calculate the maximum row size of a matrix for a given memory threshold.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,4 +47,5 @@ max-args = 10
 disable = [
   "missing-module-docstring",
   "logging-fstring-interpolation",
+  "too-many-locals",
 ]

--- a/tests/cosine_similarity_top_k_test.py
+++ b/tests/cosine_similarity_top_k_test.py
@@ -32,10 +32,13 @@ def test_cosine_similarity_top_k_big(n_items, top_k):
 
 @pytest.mark.parametrize("n_items, top_k", [(5000, 66), (10000, 100)])
 @pytest.mark.parametrize("density", [0.25, 0.1, 0.01])
-def test_cosine_similarity_top_k_big_sparse(n_items, top_k, density):
+@pytest.mark.parametrize("sparse_format", ["csr", "csc", "coo"])
+def test_cosine_similarity_top_k_big_sparse(n_items, top_k, density, sparse_format):
     embedding_dim = 50
     max_memory = int(10e6)  # force chunking by taking small amount of memory ~10MB
-    embeddings = srand(n_items, embedding_dim, density=density, format="csr", random_state=21)
+    embeddings = srand(
+        n_items, embedding_dim, density=density, format=sparse_format, random_state=21
+    )
     expected = cosine_similarity(embeddings)
     expected = get_top_k(expected, top_k)
     calculated = cosine_similarity_top_k(embeddings, top_k, max_memory)
@@ -61,10 +64,13 @@ def test_cosine_similarity_negative_top_k_big(n_items, top_k):
 
 @pytest.mark.parametrize("n_items, top_k", [(5000, -66), (10000, -100)])
 @pytest.mark.parametrize("density", [0.25, 0.1, 0.01])
-def test_cosine_similarity_negative_top_k_big_sparse(n_items, top_k, density):
+@pytest.mark.parametrize("sparse_format", ["csr", "csc", "coo"])
+def test_cosine_similarity_negative_top_k_big_sparse(n_items, top_k, density, sparse_format):
     embedding_dim = 50
     max_memory = int(10e6)  # force chunking by taking small amount of memory ~10MB
-    embeddings = srand(n_items, embedding_dim, density=density, format="csr", random_state=21)
+    embeddings = srand(
+        n_items, embedding_dim, density=density, format=sparse_format, random_state=21
+    )
     expected = cosine_similarity(embeddings)
     expected = get_top_k(expected, top_k)
     calculated = cosine_similarity_top_k(embeddings, top_k, max_memory)

--- a/tests/cosine_similarity_top_k_test.py
+++ b/tests/cosine_similarity_top_k_test.py
@@ -7,10 +7,11 @@ from chunkdot.cosine_similarity_top_k import cosine_similarity_top_k
 
 def get_top_k(matrix, top_k):
     n_items = len(matrix)
+    top_k_j = np.argpartition(matrix, -top_k)
     if top_k > 0:
-        top_k_j = np.argpartition(matrix, -top_k)[:, -top_k:]
+        top_k_j = top_k_j[:, -top_k:]
     else:
-        top_k_j = np.argpartition(matrix, -top_k)[:, :-top_k]
+        top_k_j = top_k_j[:, :-top_k]
     values = np.take_along_axis(matrix, top_k_j, axis=1).flatten()
     indices = top_k_j.flatten()
     indptr = np.arange(0, abs(top_k) * (1 + n_items), abs(top_k))
@@ -18,25 +19,10 @@ def get_top_k(matrix, top_k):
 
 
 @pytest.mark.parametrize("n_items, top_k", [(5000, 66), (10000, 100)])
-@pytest.mark.parametrize("as_csr_sparse", [True])
-def test_cosine_similarity_top_k_big(n_items, top_k, as_csr_sparse):
+def test_cosine_similarity_top_k_big(n_items, top_k):
     embedding_dim = 50
-    max_memory = int(0.1e9)  # force chunking by taking small amount of memory ~100MB
-    if as_csr_sparse:
-        embeddings = srand(n_items, embedding_dim, density=0.5, format="csr")
-    else:
-        embeddings = np.random.randn(n_items, embedding_dim)
-    expected = cosine_similarity(embeddings)
-    expected = get_top_k(expected, top_k)
-    calculated = cosine_similarity_top_k(embeddings, top_k, max_memory)
-    np.testing.assert_array_almost_equal(np.sort(calculated.data), np.sort(expected.data))
-    # np.testing.assert_array_almost_equal(calculated.toarray(), expected.toarray())
-
-
-@pytest.mark.parametrize("n_items, top_k", [(5000, -66), (10000, -100)])
-def test_cosine_similarity_negative_top_k_big(n_items, top_k):
-    embedding_dim = 50
-    max_memory = int(0.1e9)  # force chinking by taking small amount of memory ~100MB
+    max_memory = int(10e6)  # force chunking by taking small amount of memory ~10MB
+    np.random.seed(seed=21)
     embeddings = np.random.randn(n_items, embedding_dim)
     expected = cosine_similarity(embeddings)
     expected = get_top_k(expected, top_k)
@@ -44,9 +30,59 @@ def test_cosine_similarity_negative_top_k_big(n_items, top_k):
     np.testing.assert_array_almost_equal(calculated.toarray(), expected.toarray())
 
 
+@pytest.mark.parametrize("n_items, top_k", [(5000, 66), (10000, 100)])
+@pytest.mark.parametrize("density", [0.25, 0.1, 0.01])
+def test_cosine_similarity_top_k_big_sparse(n_items, top_k, density):
+    embedding_dim = 50
+    max_memory = int(10e6)  # force chunking by taking small amount of memory ~10MB
+    embeddings = srand(n_items, embedding_dim, density=density, format="csr", random_state=21)
+    expected = cosine_similarity(embeddings)
+    expected = get_top_k(expected, top_k)
+    calculated = cosine_similarity_top_k(embeddings, top_k, max_memory)
+    # There might be elements with the same similarity and it might be that in the
+    # numpy implementation of get top K items returned are different than in
+    # the numba implementation.
+    np.testing.assert_array_almost_equal(np.sort(calculated.data), np.sort(expected.data))
+    assert len(calculated.indices) == len(expected.indices)
+    np.testing.assert_array_almost_equal(calculated.indptr, expected.indptr)
+
+
+@pytest.mark.parametrize("n_items, top_k", [(5000, -66), (10000, -100)])
+def test_cosine_similarity_negative_top_k_big(n_items, top_k):
+    embedding_dim = 50
+    max_memory = int(10e6)  # force chunking by taking small amount of memory ~10MB
+    np.random.seed(seed=21)
+    embeddings = np.random.randn(n_items, embedding_dim)
+    expected = cosine_similarity(embeddings)
+    expected = get_top_k(expected, top_k)
+    calculated = cosine_similarity_top_k(embeddings, top_k, max_memory)
+    np.testing.assert_array_almost_equal(calculated.toarray(), expected.toarray())
+
+
+@pytest.mark.parametrize("n_items, top_k", [(5000, -66), (10000, -100)])
+@pytest.mark.parametrize("density", [0.25, 0.1, 0.01])
+def test_cosine_similarity_negative_top_k_big_sparse(n_items, top_k, density):
+    embedding_dim = 50
+    max_memory = int(10e6)  # force chunking by taking small amount of memory ~10MB
+    embeddings = srand(n_items, embedding_dim, density=density, format="csr", random_state=21)
+    expected = cosine_similarity(embeddings)
+    expected = get_top_k(expected, top_k)
+    calculated = cosine_similarity_top_k(embeddings, top_k, max_memory)
+    # There might be elements with the same similarity and it might be that in the
+    # numpy implementation of get top K items returned are different than in
+    # the numba implementation.
+    np.testing.assert_array_almost_equal(np.sort(calculated.data), np.sort(expected.data))
+    assert len(calculated.indices) == len(expected.indices)
+    np.testing.assert_array_almost_equal(calculated.indptr, expected.indptr)
+
+
 @pytest.mark.parametrize("n_items", [10, 1000])
-def test_cosine_similarity_error(n_items):
+@pytest.mark.parametrize("as_csr_sparse", [False, True])
+def test_cosine_similarity_error(n_items, as_csr_sparse):
+    np.random.seed(seed=21)
     embeddings = np.random.randn(n_items, 100)
+    if as_csr_sparse:
+        embeddings = csr_matrix(embeddings)
 
     top_k = n_items
     with pytest.raises(ValueError):
@@ -55,8 +91,12 @@ def test_cosine_similarity_error(n_items):
 
 @pytest.mark.parametrize("n_items, top_k", [(10, 4), (51, 10), (100, 15), (732, 50), (1000, 77)])
 @pytest.mark.parametrize("embedding_dim", [10, 33, 66, 100])
-def test_cosine_similarity_top_k(n_items, top_k, embedding_dim):
+@pytest.mark.parametrize("as_csr_sparse", [False, True])
+def test_cosine_similarity_top_k(n_items, top_k, embedding_dim, as_csr_sparse):
+    np.random.seed(seed=21)
     embeddings = np.random.randn(n_items, embedding_dim)
+    if as_csr_sparse:
+        embeddings = csr_matrix(embeddings)
     expected = cosine_similarity(embeddings)
     expected = get_top_k(expected, top_k)
     calculated = cosine_similarity_top_k(embeddings, top_k)
@@ -64,7 +104,8 @@ def test_cosine_similarity_top_k(n_items, top_k, embedding_dim):
 
 
 @pytest.mark.parametrize("input_type", ["int8", "int16", "int32", "int64", "float32", "float64"])
-def test_cosine_similarity_top_k_manual(input_type):
+@pytest.mark.parametrize("as_csr_sparse", [False, True])
+def test_cosine_similarity_top_k_manual(input_type, as_csr_sparse):
     embeddings = np.array(
         [
             [1, 3, 5, 2, -1, 10],
@@ -73,6 +114,8 @@ def test_cosine_similarity_top_k_manual(input_type):
             [23, 65, -34, 1, 44, 56],
         ]
     ).astype(input_type)
+    if as_csr_sparse:
+        embeddings = csr_matrix(embeddings)
     top_k = 3
     expected_type = cosine_similarity(embeddings).dtype
     expected = np.array(
@@ -90,7 +133,8 @@ def test_cosine_similarity_top_k_manual(input_type):
 
 
 @pytest.mark.parametrize("input_type", ["uint8", "uint16", "uint32", "uint64"])
-def test_cosine_similarity_top_k_manual_unit(input_type):
+@pytest.mark.parametrize("as_csr_sparse", [False, True])
+def test_cosine_similarity_top_k_manual_unit(input_type, as_csr_sparse):
     embeddings = np.array(
         [
             [1, 3, 5, 2, 1, 10],
@@ -99,6 +143,8 @@ def test_cosine_similarity_top_k_manual_unit(input_type):
             [23, 65, 34, 1, 44, 56],
         ]
     ).astype(input_type)
+    if as_csr_sparse:
+        embeddings = csr_matrix(embeddings)
     top_k = 3
     expected_type = cosine_similarity(embeddings).dtype
     expected = np.array(
@@ -116,7 +162,8 @@ def test_cosine_similarity_top_k_manual_unit(input_type):
 
 
 @pytest.mark.parametrize("input_type", ["int8", "int16", "int32", "int64", "float32", "float64"])
-def test_cosine_similarity_negative_top_k_manual(input_type):
+@pytest.mark.parametrize("as_csr_sparse", [False, True])
+def test_cosine_similarity_negative_top_k_manual(input_type, as_csr_sparse):
     embeddings = np.array(
         [
             [1, 3, 5, 2, -1, 10],
@@ -125,6 +172,8 @@ def test_cosine_similarity_negative_top_k_manual(input_type):
             [23, 65, -34, 1, 44, 56],
         ]
     ).astype(input_type)
+    if as_csr_sparse:
+        embeddings = csr_matrix(embeddings)
     top_k = -2
     expected_type = cosine_similarity(embeddings).dtype
     expected = np.array(
@@ -141,8 +190,23 @@ def test_cosine_similarity_negative_top_k_manual(input_type):
 
 
 @pytest.mark.parametrize("top_k", [1, 2, 3])
-def test_cosine_similarity_negative_top_k_zero_rows(top_k):
+@pytest.mark.parametrize("as_csr_sparse", [False, True])
+def test_cosine_similarity_top_k_zero_rows(top_k, as_csr_sparse):
     embeddings = np.array([[0, 0, 0], [34, 22, 11], [0, 0, 0], [11, 21, 34]])
+    if as_csr_sparse:
+        embeddings = csr_matrix(embeddings)
+    expected = cosine_similarity(embeddings)
+    expected = get_top_k(expected, top_k)
+    calculated = cosine_similarity_top_k(embeddings, top_k)
+    np.testing.assert_array_almost_equal(calculated.toarray(), expected.toarray())
+
+
+@pytest.mark.parametrize("top_k", [-1, -2, -3])
+@pytest.mark.parametrize("as_csr_sparse", [False, True])
+def test_cosine_similarity_negative_top_k_zero_rows(top_k, as_csr_sparse):
+    embeddings = np.array([[0, 0, 0], [34, 22, 11], [0, 0, 0], [11, 21, 34]])
+    if as_csr_sparse:
+        embeddings = csr_matrix(embeddings)
     expected = cosine_similarity(embeddings)
     expected = get_top_k(expected, top_k)
     calculated = cosine_similarity_top_k(embeddings, top_k)


### PR DESCRIPTION
Wanted to use scipy operations for sparse matrices but unfortunately they are not supporte via numba so I had to write my own sparse matrix multiplication implementation. The tests are quite extensive so I hope to catch most of edge cases. I also added tests for complete rows with zeros, resulting in the same output as sklearn cosine similarity (do not normalize rows with all zeros).